### PR TITLE
Add country dropdowns with flags and currencies config

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,32 @@
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
   const hello = document.getElementById('hello');
   const formContainer = document.getElementById('form-container');
   const form = document.getElementById('search-form');
   const progress = document.getElementById('progress');
   const progressBar = document.getElementById('progress-bar');
+  const startSelect = document.getElementById('start');
+  const destinationSelect = document.getElementById('destination');
+
+  function populateSelect(select, countries, placeholder) {
+    const defaultOption = document.createElement('option');
+    defaultOption.value = '';
+    defaultOption.textContent = placeholder;
+    defaultOption.disabled = true;
+    defaultOption.selected = true;
+    select.appendChild(defaultOption);
+
+    countries.forEach((country) => {
+      const option = document.createElement('option');
+      option.value = country.code;
+      option.textContent = `${country.flag} ${country.name}`;
+      select.appendChild(option);
+    });
+  }
+
+  const response = await fetch('countries.json');
+  const { sourceCountries, destinationCountries } = await response.json();
+  populateSelect(startSelect, sourceCountries, 'Select source country');
+  populateSelect(destinationSelect, destinationCountries, 'Select destination country');
 
   hello.addEventListener('animationend', () => {
     formContainer.classList.remove('hidden');

--- a/countries.json
+++ b/countries.json
@@ -1,0 +1,8 @@
+{
+  "sourceCountries": [
+    { "code": "AM", "name": "Armenia", "flag": "\uD83C\uDDE6\uD83C\uDDF2" }
+  ],
+  "destinationCountries": [
+    { "code": "AM", "name": "Armenia", "flag": "\uD83C\uDDE6\uD83C\uDDF2" }
+  ]
+}

--- a/currencies.json
+++ b/currencies.json
@@ -1,0 +1,6 @@
+{
+  "currencies": [
+    { "code": "RUB", "symbol": "\u20BD", "name": "Russian Ruble", "country": "Russia" },
+    { "code": "USD", "symbol": "\u0024", "name": "US Dollar", "country": "United States" }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <div id="hello">Hello</div>
   <div id="form-container" class="hidden">
     <form id="search-form">
-      <input type="text" id="start" placeholder="Source" required />
-      <input type="text" id="destination" placeholder="Destination" required />
+      <select id="start" required></select>
+      <select id="destination" required></select>
       <input type="number" id="budget" placeholder="Budget ($)" required />
       <button type="submit" class="submit-btn">Search</button>
     </form>

--- a/style.css
+++ b/style.css
@@ -70,14 +70,16 @@ html, body {
   gap: 1rem;
 }
 
-#search-form input {
+#search-form input,
+#search-form select {
   padding: 0.75rem 1rem;
   border: 1px solid #ccc;
   border-radius: 4px;
   transition: border-color 0.3s, box-shadow 0.3s;
 }
 
-#search-form input:focus {
+#search-form input:focus,
+#search-form select:focus {
   outline: none;
   border-color: #4caf50;
   box-shadow: 0 0 0 3px rgba(76, 175, 80, 0.2);


### PR DESCRIPTION
## Summary
- maintain separate lists of supported source and destination countries using a JSON config
- use dropdowns with flag icons for source and destination inputs
- style select elements consistently
- track supported currencies with symbol, name, and country

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a908ee779883228d24a8e413d84593