### PR TITLE
Setup Express server with tours and events endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,22 @@ The project is split into a frontend and backend:
 - **client/** – React frontend powered by Vite. Start the development server with `npm run dev` inside the `client` folder.
 - **server/** – Express backend for API and services. Start the server with `npm start` inside the `server` folder.
 
+### Configuration
+
+The backend uses environment variables for external API credentials. Copy `server/.env.example` to `server/.env` and fill in your values:
+
+```
+PORT=3000
+TOURVISOR_LOGIN=your_login
+TOURVISOR_PASSWORD=your_password
+TICKETMASTER_API_KEY=your_ticketmaster_api_key
+```
+
+### API Endpoints
+
+- `GET /api/tours` – fetch tours from Tourvisor using the credentials above.
+- `GET /api/events` – fetch events data from Ticketmaster.
+
 ## Development
 
 Install dependencies and start the development server:

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,4 @@
+PORT=3000
+TOURVISOR_LOGIN=your_login
+TOURVISOR_PASSWORD=your_password
+TICKETMASTER_API_KEY=your_ticketmaster_api_key

--- a/server/index.js
+++ b/server/index.js
@@ -1,14 +1,49 @@
 const express = require('express');
 const axios = require('axios');
 const dotenv = require('dotenv');
+const cors = require('cors');
 
 dotenv.config();
 
 const app = express();
+
+// Middleware
+app.use(cors());
+app.use(express.json());
+
 const PORT = process.env.PORT || 3000;
 
 app.get('/', (req, res) => {
   res.send('Server is running');
+});
+
+app.get('/api/tours', async (req, res) => {
+  try {
+    const response = await axios.get('https://export.tourvisor.ru/search', {
+      params: {
+        login: process.env.TOURVISOR_LOGIN,
+        password: process.env.TOURVISOR_PASSWORD,
+        ...req.query
+      }
+    });
+    res.json(response.data);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to fetch tours' });
+  }
+});
+
+app.get('/api/events', async (req, res) => {
+  try {
+    const response = await axios.get('https://app.ticketmaster.com/discovery/v2/events.json', {
+      params: {
+        apikey: process.env.TICKETMASTER_API_KEY,
+        ...req.query
+      }
+    });
+    res.json(response.data);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to fetch events' });
+  }
 });
 
 app.listen(PORT, () => {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.11.0",
+        "cors": "^2.8.5",
         "dotenv": "^17.2.1",
         "express": "^5.1.0"
       }
@@ -151,6 +152,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/debug": {
@@ -642,6 +656,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,7 @@
   "type": "commonjs",
   "dependencies": {
     "axios": "^1.11.0",
+    "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0"
   }


### PR DESCRIPTION
## Summary
- add centralized env config and example file for backend credentials
- create tours and events routes with CORS and JSON parsing
- document configuration and API endpoints in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a91407c3348322b1f2ee60cb7eec44