### PR TITLE
feat: mock tour search service

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const axios = require('axios');
 const dotenv = require('dotenv');
 const cors = require('cors');
+const { searchTours } = require('./services/toursService');
 
 dotenv.config();
 
@@ -19,14 +20,9 @@ app.get('/', (req, res) => {
 
 app.get('/api/tours', async (req, res) => {
   try {
-    const response = await axios.get('https://export.tourvisor.ru/search', {
-      params: {
-        login: process.env.TOURVISOR_LOGIN,
-        password: process.env.TOURVISOR_PASSWORD,
-        ...req.query
-      }
-    });
-    res.json(response.data);
+    const { departureCode, destinationCode, budget } = req.query;
+    const tours = await searchTours({ departureCode, destinationCode, budget });
+    res.json(tours);
   } catch (error) {
     res.status(500).json({ error: 'Failed to fetch tours' });
   }

--- a/server/services/toursService.js
+++ b/server/services/toursService.js
@@ -1,0 +1,33 @@
+// TODO: Replace this mock implementation with real Tourvisor API calls once credentials are available.
+// For now, return hard-coded sample tours.
+
+/**
+ * Search for tours using Tourvisor API (mock implementation).
+ *
+ * @param {Object} params
+ * @param {string} params.departureCode - IATA code for departure city.
+ * @param {string} params.destinationCode - IATA code for destination city.
+ * @param {number|string} params.budget - Maximum budget for the tour.
+ * @returns {Promise<Array<Object>>} Array of tour objects.
+ */
+async function searchTours({ departureCode, destinationCode, budget }) {
+  // The parameters are currently unused in this mock.
+  return [
+    {
+      operator: 'Mock Operator',
+      price: 1000,
+      departureDate: '2024-07-01',
+      returnDate: '2024-07-10',
+      link: 'https://example.com/tour/1'
+    },
+    {
+      operator: 'Demo Travel',
+      price: 800,
+      departureDate: '2024-08-05',
+      returnDate: '2024-08-15',
+      link: 'https://example.com/tour/2'
+    }
+  ];
+}
+
+module.exports = { searchTours };


### PR DESCRIPTION
## Summary
- add mock tour search service returning sample data and document future API integration
- use `searchTours` in `/api/tours` endpoint to respond with mock results

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a914c674048322963fd196a00103cd