### PR TITLE
feat: add events service with provider registry

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,8 +1,8 @@
 const express = require('express');
-const axios = require('axios');
 const dotenv = require('dotenv');
 const cors = require('cors');
 const { searchTours } = require('./services/toursService');
+const { getEvents } = require('./services/eventsService');
 
 dotenv.config();
 
@@ -30,13 +30,9 @@ app.get('/api/tours', async (req, res) => {
 
 app.get('/api/events', async (req, res) => {
   try {
-    const response = await axios.get('https://app.ticketmaster.com/discovery/v2/events.json', {
-      params: {
-        apikey: process.env.TICKETMASTER_API_KEY,
-        ...req.query
-      }
-    });
-    res.json(response.data);
+    const { country, startDate, endDate } = req.query;
+    const events = await getEvents(country, { startDate, endDate });
+    res.json(events);
   } catch (error) {
     res.status(500).json({ error: 'Failed to fetch events' });
   }

--- a/server/providers/ticketmasterProvider.js
+++ b/server/providers/ticketmasterProvider.js
@@ -1,0 +1,44 @@
+const axios = require('axios');
+
+const BASE_URL = 'https://app.ticketmaster.com/discovery/v2/events.json';
+
+/**
+ * Fetch events from Ticketmaster API.
+ *
+ * @param {string} countryCode - ISO country code.
+ * @param {Object} [dateRange] - Optional date range with startDate and endDate.
+ * @returns {Promise<Array<Object>>} Normalized event objects.
+ */
+async function fetchEvents(countryCode, dateRange = {}) {
+  const apiKey = process.env.TICKETMASTER_API_KEY;
+  if (!apiKey) {
+    return [];
+  }
+
+  const params = {
+    countryCode,
+    apikey: apiKey
+  };
+
+  if (dateRange.startDate) {
+    params.startDateTime = new Date(dateRange.startDate).toISOString();
+  }
+  if (dateRange.endDate) {
+    params.endDateTime = new Date(dateRange.endDate).toISOString();
+  }
+
+  try {
+    const response = await axios.get(BASE_URL, { params });
+    const events = response.data?._embedded?.events || [];
+    return events.map((ev) => ({
+      name: ev.name,
+      date: ev.dates?.start?.dateTime || ev.dates?.start?.localDate,
+      venue: ev._embedded?.venues?.[0]?.name || '',
+      url: ev.url
+    }));
+  } catch (err) {
+    return [];
+  }
+}
+
+module.exports = { fetchEvents };

--- a/server/providers/tomsarkghProvider.js
+++ b/server/providers/tomsarkghProvider.js
@@ -1,0 +1,50 @@
+const axios = require('axios');
+
+const BASE_URL = 'https://www.tomsarkgh.am/sitemap/events';
+
+/**
+ * Fetch events from Tomsarkgh sitemap.
+ *
+ * @param {string} countryCode - ISO country code (unused).
+ * @param {Object} [dateRange] - Optional date range with startDate and endDate.
+ * @returns {Promise<Array<Object>>} Normalized event objects.
+ */
+async function fetchEvents(countryCode, dateRange = {}) {
+  const pages = [0, 1];
+  const results = [];
+
+  for (const page of pages) {
+    try {
+      const { data } = await axios.get(`${BASE_URL}/${page}`);
+      const entries = data.match(/<url>(.*?)<\/url>/gs) || [];
+      for (const entry of entries) {
+        const locMatch = entry.match(/<loc>(.*?)<\/loc>/);
+        const dateMatch = entry.match(/<lastmod>(.*?)<\/lastmod>/);
+        if (locMatch && dateMatch) {
+          const url = locMatch[1];
+          let name = url.split('/').pop().replace('.html', '');
+          name = decodeURIComponent(name).replace(/-/g, ' ');
+          const date = dateMatch[1];
+          if (dateRange.startDate && new Date(date) < new Date(dateRange.startDate)) {
+            continue;
+          }
+          if (dateRange.endDate && new Date(date) > new Date(dateRange.endDate)) {
+            continue;
+          }
+          results.push({
+            name,
+            date,
+            venue: '',
+            url
+          });
+        }
+      }
+    } catch (err) {
+      // ignore fetch errors for individual pages
+    }
+  }
+
+  return results;
+}
+
+module.exports = { fetchEvents };

--- a/server/services/eventsService.js
+++ b/server/services/eventsService.js
@@ -1,0 +1,26 @@
+const ticketmasterProvider = require('../providers/ticketmasterProvider');
+const tomsarkghProvider = require('../providers/tomsarkghProvider');
+
+// Mapping of ISO country codes to provider modules
+const providerRegistry = {
+  US: ticketmasterProvider,
+  AM: tomsarkghProvider
+};
+
+/**
+ * Retrieve events using the appropriate provider based on country code.
+ *
+ * @param {string} countryCode - ISO country code.
+ * @param {Object} [dateRange] - Optional date range with startDate and endDate.
+ * @returns {Promise<Array<Object>>} Array of normalized events.
+ */
+async function getEvents(countryCode = 'US', dateRange = {}) {
+  const code = countryCode.toUpperCase();
+  const provider = providerRegistry[code] || ticketmasterProvider;
+  if (!provider) {
+    return [];
+  }
+  return provider.fetchEvents(code, dateRange);
+}
+
+module.exports = { getEvents, providerRegistry };


### PR DESCRIPTION
## Summary
- add Ticketmaster and Tomsarkgh providers for event data
- create events service that selects provider by country code
- wire unified events endpoint in server

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9156cef3483228af215829dfed989