### PR TITLE
Add scrollable results page for tours and events

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ TICKETMASTER_API_KEY=your_ticketmaster_api_key
 - `GET /api/tours` – fetch tours from Tourvisor using the credentials above.
 - `GET /api/events` – fetch events data from Ticketmaster.
 
+## Results Page and Navigation
+
+Searches on the landing page fetch tours and events and then scroll the viewport to a full-screen results page. The layout uses
+CSS scroll snapping to treat the landing and results sections as vertical pages. Tours appear in the larger left column with
+links to Tourvisor, while events are listed on the right with links to their ticket providers.
+
 ## Development
 
 Install dependencies and start the development server:

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,0 +1,65 @@
+import React, { useState, useRef } from 'react';
+import LandingPage from './LandingPage';
+import ResultsPage from './ResultsPage';
+
+/**
+ * App wraps LandingPage and ResultsPage in a scroll-snap container.
+ * After a successful search it scrolls smoothly to the results section.
+ */
+export default function App() {
+  const [tours, setTours] = useState([]);
+  const [events, setEvents] = useState([]);
+  const containerRef = useRef(null);
+
+  const handleSearch = async ({ departure, destination, budget, startDate, endDate }) => {
+    const tourParams = new URLSearchParams({
+      departureCode: departure,
+      destinationCode: destination,
+      budget
+    });
+    const eventParams = new URLSearchParams({
+      country: destination,
+      startDate,
+      endDate
+    });
+    try {
+      const [tourRes, eventRes] = await Promise.all([
+        fetch(`/api/tours?${tourParams.toString()}`),
+        fetch(`/api/events?${eventParams.toString()}`)
+      ]);
+      const toursData = await tourRes.json();
+      const eventsData = await eventRes.json();
+      setTours(toursData);
+      setEvents(eventsData);
+      if (containerRef.current) {
+        containerRef.current.scrollTo({
+          top: containerRef.current.clientHeight,
+          behavior: 'smooth'
+        });
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const containerStyle = {
+    height: '100vh',
+    overflowY: 'auto',
+    scrollSnapType: 'y mandatory'
+  };
+  const pageStyle = {
+    scrollSnapAlign: 'start'
+  };
+
+  return (
+    <div ref={containerRef} style={containerStyle}>
+      <div style={pageStyle}>
+        <LandingPage onSearch={handleSearch} />
+      </div>
+      <div style={pageStyle}>
+        <ResultsPage tours={tours} events={events} />
+      </div>
+    </div>
+  );
+}
+

--- a/client/src/LandingPage.jsx
+++ b/client/src/LandingPage.jsx
@@ -4,10 +4,10 @@ import WorldMap from './WorldMap';
 
 /**
  * LandingPage shows the trip form and a world map side by side.
- * It loads country options from countries.json and fetches
- * tours and events from the backend when the form is submitted.
+ * It loads country options from countries.json and notifies
+ * the parent component when the form is submitted.
  */
-export default function LandingPage() {
+export default function LandingPage({ onSearch }) {
   const [departure, setDeparture] = useState('');
   const [destination, setDestination] = useState('');
   const [budget, setBudget] = useState('');
@@ -19,18 +19,13 @@ export default function LandingPage() {
     e.preventDefault();
     setLoading(true);
     try {
-      const params = new URLSearchParams({
+      await onSearch({
         departure,
         destination,
         budget,
         startDate,
         endDate,
       });
-
-      await Promise.all([
-        fetch(`/api/tours?${params.toString()}`),
-        fetch(`/api/events?${params.toString()}`),
-      ]);
     } catch (err) {
       console.error(err);
     } finally {

--- a/client/src/ResultsPage.jsx
+++ b/client/src/ResultsPage.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+/**
+ * ResultsPage displays tours and events in two columns.
+ * The left column lists tours while the right column lists events.
+ */
+export default function ResultsPage({ tours = [], events = [] }) {
+  return (
+    <div style={{ display: 'flex', height: '100vh' }}>
+      <div
+        style={{ flex: 2, padding: '1rem', overflowY: 'auto', borderRight: '1px solid #e2e8f0' }}
+      >
+        <h2>Tours</h2>
+        {tours.length === 0 && <p>No tours found.</p>}
+        {tours.map((tour, idx) => (
+          <div
+            key={idx}
+            style={{ marginBottom: '1rem', borderBottom: '1px solid #e2e8f0', paddingBottom: '1rem' }}
+          >
+            <p><strong>{tour.operator}</strong></p>
+            <p>Price: ${tour.price}</p>
+            <p>
+              {tour.departureDate} – {tour.returnDate}
+            </p>
+            <a href={tour.link} target="_blank" rel="noopener noreferrer">View Tour</a>
+          </div>
+        ))}
+      </div>
+      <div
+        style={{ flex: 1, padding: '1rem', overflowY: 'auto', background: '#f1f5f9' }}
+      >
+        <h2>Events</h2>
+        {events.length === 0 && <p>No events found.</p>}
+        {events.map((event, idx) => (
+          <div
+            key={idx}
+            style={{ marginBottom: '1rem', borderBottom: '1px solid #e2e8f0', paddingBottom: '1rem' }}
+          >
+            <p><strong>{event.name}</strong></p>
+            <p>{event.date}</p>
+            <p>{event.venue}</p>
+            <a href={event.url} target="_blank" rel="noopener noreferrer">More info</a>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import LandingPage from './LandingPage';
+import App from './App';
 
-ReactDOM.createRoot(document.getElementById('root')).render(<LandingPage />);
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);


### PR DESCRIPTION
## Summary
- Display fetched tours and events on a new full-screen results page
- Wrap landing and results sections in a scroll-snap container and scroll to results after search
- Document vertical paging and results page behaviour in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9280494b88322ade7406792a88db9