### PR TITLE
Style pages with responsive splits

### DIFF
--- a/client/src/LandingPage.jsx
+++ b/client/src/LandingPage.jsx
@@ -34,11 +34,8 @@ export default function LandingPage({ onSearch }) {
   };
 
   return (
-    <div style={{ display: 'flex', height: '100vh' }}>
-      <form
-        onSubmit={handleSubmit}
-        style={{ flex: '0 0 300px', padding: '1rem', background: '#f1f5f9' }}
-      >
+    <div className="landing-container">
+      <form onSubmit={handleSubmit} className="landing-form">
         <h2>Plan your trip</h2>
         <div>
           <label htmlFor="departure">Departure Country</label>
@@ -100,7 +97,7 @@ export default function LandingPage({ onSearch }) {
           {loading ? 'Loading…' : 'Search'}
         </button>
       </form>
-      <div style={{ flex: 1 }}>
+      <div className="landing-map">
         <WorldMap />
       </div>
     </div>

--- a/client/src/ResultsPage.jsx
+++ b/client/src/ResultsPage.jsx
@@ -6,10 +6,8 @@ import React from 'react';
  */
 export default function ResultsPage({ tours = [], events = [] }) {
   return (
-    <div style={{ display: 'flex', height: '100vh' }}>
-      <div
-        style={{ flex: 2, padding: '1rem', overflowY: 'auto', borderRight: '1px solid #e2e8f0' }}
-      >
+    <div className="results-container">
+      <div className="tours">
         <h2>Tours</h2>
         {tours.length === 0 && <p>No tours found.</p>}
         {tours.map((tour, idx) => (
@@ -26,9 +24,7 @@ export default function ResultsPage({ tours = [], events = [] }) {
           </div>
         ))}
       </div>
-      <div
-        style={{ flex: 1, padding: '1rem', overflowY: 'auto', background: '#f1f5f9' }}
-      >
+      <div className="events">
         <h2>Events</h2>
         {events.length === 0 && <p>No events found.</p>}
         {events.map((event, idx) => (

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import './styles.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1,0 +1,73 @@
+/* Global styles based on root style.css */
+html, body, #root {
+  height: 100%;
+  margin: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
+}
+
+/* Landing page layout */
+.landing-container {
+  display: flex;
+  height: 100vh;
+}
+
+.landing-form {
+  flex: 0 0 25%;
+  padding: 1rem;
+  background: #f1f5f9;
+  overflow-y: auto;
+}
+
+.landing-map {
+  flex: 1 0 75%;
+}
+
+/* Results page layout */
+.results-container {
+  display: flex;
+  height: 100vh;
+}
+
+.results-container .tours {
+  flex: 3;
+  padding: 1rem;
+  overflow-y: auto;
+  border-right: 1px solid #e2e8f0;
+}
+
+.results-container .events {
+  flex: 1;
+  padding: 1rem;
+  overflow-y: auto;
+  background: #f1f5f9;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .landing-container,
+  .results-container {
+    flex-direction: column;
+  }
+
+  .landing-form,
+  .landing-map {
+    flex: none;
+    width: 100%;
+    max-width: 100%;
+    height: 50vh;
+  }
+
+  .results-container .tours,
+  .results-container .events {
+    flex: none;
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+  }
+
+  .results-container .tours {
+    border-right: none;
+    border-bottom: 1px solid #e2e8f0;
+  }
+}


### PR DESCRIPTION
## Summary
- Add shared stylesheet establishing app-wide colors and responsive layouts
- Use CSS classes in LandingPage and ResultsPage for 25/75 and 75/25 splits
- Import global styles into client entry

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a92917db28832296e0e57dad6cd027