### PR TITLE
feat: dynamic provider registry with EU placeholder

### DIFF
--- a/server/providers/README.md
+++ b/server/providers/README.md
@@ -1,0 +1,25 @@
+# Event Providers
+
+Each provider module must export a `fetchEvents` function and a list of ISO
+country codes it supports via `supportedCountryCodes`.
+
+```js
+const supportedCountryCodes = ['US'];
+
+/**
+ * Fetch events for a country.
+ * @param {string} countryCode
+ * @param {{startDate?: string, endDate?: string}} [dateRange]
+ * @returns {Promise<Array<{name:string,date:string,venue:string,url:string}>>}
+ */
+async function fetchEvents(countryCode, dateRange = {}) {
+  // ...
+}
+
+module.exports = { fetchEvents, supportedCountryCodes };
+```
+
+The returned events should be normalized objects containing `name`, `date`,
+`venue`, and `url` fields. `eventsService` automatically loads all providers in
+this directory and selects them based on their declared country codes. Requests
+for unsupported countries fall back to the Ticketmaster provider.

--- a/server/providers/providers.test.js
+++ b/server/providers/providers.test.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const ticketmasterProvider = require('./ticketmasterProvider');
 const tomsarkghProvider = require('./tomsarkghProvider');
+const ticketmasterEuProvider = require('./ticketmasterEuProvider');
 
 // Mock axios to avoid real HTTP requests. Real API calls should be mocked with
 // more detailed fixtures when the providers are fully implemented.
@@ -29,6 +30,34 @@ describe('event providers', () => {
       }
     });
     const events = await ticketmasterProvider.fetchEvents('US');
+    expect(Array.isArray(events)).toBe(true);
+    expect(events[0]).toEqual({
+      name: 'Concert',
+      date: '2024-01-01T00:00:00Z',
+      venue: 'Hall',
+      url: 'https://example.com/concert'
+    });
+    process.env.TICKETMASTER_API_KEY = original;
+  });
+
+  test('ticketmasterEuProvider returns normalized events', async () => {
+    const original = process.env.TICKETMASTER_API_KEY;
+    process.env.TICKETMASTER_API_KEY = 'dummy';
+    axios.get.mockResolvedValue({
+      data: {
+        _embedded: {
+          events: [
+            {
+              name: 'Concert',
+              dates: { start: { dateTime: '2024-01-01T00:00:00Z' } },
+              _embedded: { venues: [{ name: 'Hall' }] },
+              url: 'https://example.com/concert'
+            }
+          ]
+        }
+      }
+    });
+    const events = await ticketmasterEuProvider.fetchEvents('GB');
     expect(Array.isArray(events)).toBe(true);
     expect(events[0]).toEqual({
       name: 'Concert',

--- a/server/providers/ticketmasterEuProvider.js
+++ b/server/providers/ticketmasterEuProvider.js
@@ -1,0 +1,10 @@
+const ticketmasterProvider = require('./ticketmasterProvider');
+
+// Placeholder provider for several EU markets using Ticketmaster API.
+const supportedCountryCodes = ['GB', 'DE', 'FR', 'ES', 'IT'];
+
+async function fetchEvents(countryCode, dateRange = {}) {
+  return ticketmasterProvider.fetchEvents(countryCode, dateRange);
+}
+
+module.exports = { fetchEvents, supportedCountryCodes };

--- a/server/providers/ticketmasterProvider.js
+++ b/server/providers/ticketmasterProvider.js
@@ -2,6 +2,8 @@ const axios = require('axios');
 
 const BASE_URL = 'https://app.ticketmaster.com/discovery/v2/events.json';
 
+// ISO country codes handled by this provider.
+const supportedCountryCodes = ['US'];
 /**
  * Fetch events from Ticketmaster API.
  *
@@ -41,4 +43,4 @@ async function fetchEvents(countryCode, dateRange = {}) {
   }
 }
 
-module.exports = { fetchEvents };
+module.exports = { fetchEvents, supportedCountryCodes };

--- a/server/providers/tomsarkghProvider.js
+++ b/server/providers/tomsarkghProvider.js
@@ -2,6 +2,8 @@ const axios = require('axios');
 
 const BASE_URL = 'https://www.tomsarkgh.am/sitemap/events';
 
+// ISO country codes handled by this provider.
+const supportedCountryCodes = ['AM'];
 /**
  * Fetch events from Tomsarkgh sitemap.
  *
@@ -47,4 +49,4 @@ async function fetchEvents(countryCode, dateRange = {}) {
   return results;
 }
 
-module.exports = { fetchEvents };
+module.exports = { fetchEvents, supportedCountryCodes };

--- a/server/services/eventsService.test.js
+++ b/server/services/eventsService.test.js
@@ -1,0 +1,31 @@
+const ticketmasterProvider = require('../providers/ticketmasterProvider');
+const tomsarkghProvider = require('../providers/tomsarkghProvider');
+const ticketmasterEuProvider = require('../providers/ticketmasterEuProvider');
+
+jest.spyOn(ticketmasterProvider, 'fetchEvents').mockResolvedValue(['tm']);
+jest.spyOn(tomsarkghProvider, 'fetchEvents').mockResolvedValue(['ts']);
+jest.spyOn(ticketmasterEuProvider, 'fetchEvents').mockResolvedValue(['eu']);
+
+const { getEvents } = require('./eventsService');
+
+describe('eventsService provider selection', () => {
+  beforeEach(() => {
+    ticketmasterProvider.fetchEvents.mockClear();
+    tomsarkghProvider.fetchEvents.mockClear();
+    ticketmasterEuProvider.fetchEvents.mockClear();
+  });
+
+  test('selects provider based on country code and defaults to Ticketmaster', async () => {
+    await expect(getEvents('US')).resolves.toEqual(['tm']);
+    expect(ticketmasterProvider.fetchEvents).toHaveBeenCalledWith('US', {});
+
+    await expect(getEvents('AM')).resolves.toEqual(['ts']);
+    expect(tomsarkghProvider.fetchEvents).toHaveBeenCalledWith('AM', {});
+
+    await expect(getEvents('GB')).resolves.toEqual(['eu']);
+    expect(ticketmasterEuProvider.fetchEvents).toHaveBeenCalledWith('GB', {});
+
+    await expect(getEvents('XX')).resolves.toEqual(['tm']);
+    expect(ticketmasterProvider.fetchEvents).toHaveBeenCalledWith('XX', {});
+  });
+});


### PR DESCRIPTION
## Summary
- document provider interface for event sources
- load providers dynamically and default to Ticketmaster
- add placeholder Ticketmaster EU provider and tests for provider selection

## Testing
- `npm run lint`
- `npm test` *(fails: Support for the experimental syntax 'jsx' isn't currently enabled in client/src/__tests__/App.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d7e76fa48322ac0a23bd49052fc3